### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently only supports linux.
 # Installation
 
 ```
-go get github.com/nuyshi/traproxy/traproxy
+go get github.com/nyushi/traproxy/traproxy
 ```
 
 # How to use


### PR DESCRIPTION
Installation で レポジトリ指定のとこが typo ってるみたいです。

ごかくにんください